### PR TITLE
Don't set the number of replicas on new deployments

### DIFF
--- a/k8s/deployments.go
+++ b/k8s/deployments.go
@@ -468,7 +468,6 @@ func newDeployment(app *models.App, ps *api.PodSpec) (d *extensions.Deployment) 
 			},
 		},
 		Spec: extensions.DeploymentSpec{
-			Replicas: int32(app.Scale),
 			Strategy: extensions.DeploymentStrategy{
 				Type: extensions.RollingUpdateDeploymentStrategyType,
 				RollingUpdate: &extensions.RollingUpdateDeployment{


### PR DESCRIPTION
The reason is that the app's number is not synced with the hpa
and a deployment may cause a huge decrease on the number of
running pods and consequently service unavailability.