### PR TITLE
Fix deploy timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [NEXT_RELEASE]
+### Fixed
+- Fix deploy timeouts by sending a few bytes at a constant time interval to the
+  network connection in use (as required by the idle timeout of the aws classic
+  elb for instance)
+
 ## [0.3.0] - 2017-04-07
 ### Added
 - Support for non-web process types


### PR DESCRIPTION
Deploy is a streaming operation and we need the connection open even with the presence of firewalls or load balancers that have idle timeouts. As we don't control go-swagger autogenerated server we send a "ping" to the client every 30 seconds by default (this value may be changed using the TERESADEPLOY_KEEPALIVE_TIMEOUT env var).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luizalabs/teresa-api/174)
<!-- Reviewable:end -->
