### PR TITLE
Fix multi teams tokens by avoiding pointer to range var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [NEXT_RELEASE]
 ### Fixed
 - Finish the merge with `teresa-cli` by removing all references to the old repo
+- Multi team tokens. Before this fix a user would get access only to apps
+  from one of its teams.
 
 ## [0.3.1] - 2017-04-24
 ### Fixed

--- a/k8s/users.go
+++ b/k8s/users.go
@@ -48,11 +48,11 @@ func (c users) getWithTeams(userEmail string, l *log.Entry) (user *models.User, 
 	user.Email = &su.Email
 	user.IsAdmin = &su.IsAdmin
 	user.Name = &su.Name
-	for _, st := range su.Teams {
+	for i, _ := range su.Teams {
 		t := &models.Team{}
-		t.Name = &st.Name
-		t.URL = st.URL
-		t.Email = strfmt.Email(st.Email)
+		t.Name = &su.Teams[i].Name
+		t.URL = su.Teams[i].URL
+		t.Email = strfmt.Email(su.Teams[i].Email)
 		t.IAmMember = true
 		user.Teams = append(user.Teams, t)
 	}


### PR DESCRIPTION
Before this fix a user would get access only to apps from one of its teams.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luizalabs/teresa-api/186)
<!-- Reviewable:end -->
