### PR TITLE
Use grpc status for errors

### DIFF
--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -1,21 +1,13 @@
 package client
 
 import (
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func GetErrorMsg(err error) string {
-	// TODO: we'll change this mess
-	switch grpc.Code(err) {
-	case codes.PermissionDenied:
-		return "Permission Denied"
-	case codes.Unavailable:
-		return "Server Unavailable"
-	case codes.AlreadyExists:
-		return "Resource Already Exists"
-	case codes.NotFound:
-		return "Resource Not Found"
+	stat, ok := status.FromError(err)
+	if !ok {
+		return err.Error()
 	}
-	return err.Error()
+	return stat.Message()
 }

--- a/pkg/client/errors_test.go
+++ b/pkg/client/errors_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/luizalabs/teresa-api/pkg/server/auth"
 )
@@ -16,7 +16,7 @@ func TestGetErrorMsg(t *testing.T) {
 		expected string
 	}{
 		{auth.ErrPermissionDenied, "Permission Denied"},
-		{grpc.Errorf(codes.Unavailable, ""), "Server Unavailable"},
+		{status.Errorf(codes.Unavailable, "Server Unavailable"), "Server Unavailable"},
 		{errors.New("Generic Error"), "Generic Error"},
 	}
 

--- a/pkg/server/auth/errors.go
+++ b/pkg/server/auth/errors.go
@@ -1,8 +1,8 @@
 package auth
 
 import (
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-var ErrPermissionDenied = grpc.Errorf(codes.PermissionDenied, "Permission Denied")
+var ErrPermissionDenied = status.Errorf(codes.PermissionDenied, "Permission Denied")


### PR DESCRIPTION
This way the client always return a clean and specific error message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luizalabs/teresa-api/195)
<!-- Reviewable:end -->
