### PR TITLE
create a custom writer to use with logs of grpc

### DIFF
--- a/pkg/server/log.go
+++ b/pkg/server/log.go
@@ -1,23 +1,23 @@
 package server
 
 import (
+	"bytes"
 	"io"
 	"log"
-	"strings"
 )
 
 type FilteredWriter struct {
 	io.Writer
 }
 
-var msgsToFilter = []string{
-	"http2Server.HandleStreams failed to receive the preface from client",
-	"failed to complete security handshake from",
+var msgsToFilter = [][]byte{
+	[]byte("http2Server.HandleStreams failed to receive the preface from client"),
+	[]byte("failed to complete security handshake from"),
 }
 
 func (f *FilteredWriter) Write(b []byte) (int, error) {
 	for _, msg := range msgsToFilter {
-		if strings.Contains(string(b), msg) {
+		if bytes.Contains(b, msg) {
 			return 0, nil
 		}
 	}

--- a/pkg/server/log.go
+++ b/pkg/server/log.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"io"
+	"log"
+	"strings"
+)
+
+type FilteredWriter struct {
+	io.Writer
+}
+
+var msgsToFilter = []string{
+	"http2Server.HandleStreams failed to receive the preface from client",
+	"failed to complete security handshake from",
+}
+
+func (f *FilteredWriter) Write(b []byte) (int, error) {
+	for _, msg := range msgsToFilter {
+		if strings.Contains(string(b), msg) {
+			return 0, nil
+		}
+	}
+	return f.Writer.Write(b)
+}
+
+func NewLogger(w io.Writer) *log.Logger {
+	return log.New(&FilteredWriter{Writer: w}, "gRPC: ", log.Ldate|log.Ltime)
+}

--- a/pkg/server/log_test.go
+++ b/pkg/server/log_test.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestFilteredWriter(t *testing.T) {
+	var testCases = []struct {
+		filter   []string
+		in       string
+		expected string
+	}{
+		{[]string{"please ignore"}, "useless msg please ignore", ""},
+		{[]string{}, "a message", "a message"},
+		{[]string{"please ignore"}, "very important info", "very important info"},
+		{[]string{"please ignore", "useless"}, "useless msg", ""},
+	}
+
+	for _, tc := range testCases {
+		msgsToFilter = tc.filter
+
+		b := new(bytes.Buffer)
+		w := &FilteredWriter{Writer: b}
+
+		fmt.Fprint(w, tc.in)
+
+		actual := b.String()
+		if actual != tc.expected {
+			t.Errorf("expected %s, got %s", tc.expected, actual)
+		}
+	}
+}

--- a/pkg/server/log_test.go
+++ b/pkg/server/log_test.go
@@ -8,14 +8,14 @@ import (
 
 func TestFilteredWriter(t *testing.T) {
 	var testCases = []struct {
-		filter   []string
+		filter   [][]byte
 		in       string
 		expected string
 	}{
-		{[]string{"please ignore"}, "useless msg please ignore", ""},
-		{[]string{}, "a message", "a message"},
-		{[]string{"please ignore"}, "very important info", "very important info"},
-		{[]string{"please ignore", "useless"}, "useless msg", ""},
+		{[][]byte{[]byte("please ignore")}, "useless msg please ignore", ""},
+		{[][]byte{}, "a message", "a message"},
+		{[][]byte{[]byte("please ignore")}, "very important info", "very important info"},
+		{[][]byte{[]byte("please ignore"), []byte("useless")}, "useless msg", ""},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"os"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/recovery"
@@ -18,6 +19,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/grpclog"
 )
 
 type Options struct {
@@ -67,6 +69,7 @@ func New(opt Options) (*Server, error) {
 	}
 
 	s := grpc.NewServer(sOpts...)
+	grpclog.SetLogger(NewLogger(os.Stdout))
 
 	us := user.NewService(uOps)
 	us.RegisterService(s)


### PR DESCRIPTION
Why? The aws elb performs health-checks with HTTP/1 protocol and without TLS certificates. It makes a mess on Teresa logs. To avoid silencing logs completely I created a simple mechanism to filter some log messages. Let me know what you think.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luizalabs/teresa-api/220)
<!-- Reviewable:end -->