### PR TITLE
remove timeout from k8s client

### DIFF
--- a/pkg/server/k8s/client.go
+++ b/pkg/server/k8s/client.go
@@ -497,7 +497,6 @@ func newInClusterK8sClient(conf *Config) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	k8sConf.Timeout = conf.Timeout
 	kc, err := kubernetes.NewForConfig(k8sConf)
 	if err != nil {
 		return nil, err
@@ -512,7 +511,6 @@ func newOutOfClusterK8sClient(conf *Config) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	k8sConf.Timeout = conf.Timeout
 	kc, err := kubernetes.NewForConfig(k8sConf)
 	if err != nil {
 		return nil, err

--- a/pkg/server/k8s/k8s.go
+++ b/pkg/server/k8s/k8s.go
@@ -1,8 +1,6 @@
 package k8s
 
 import (
-	"time"
-
 	"github.com/luizalabs/teresa-api/pkg/server/app"
 	"github.com/luizalabs/teresa-api/pkg/server/deploy"
 	"k8s.io/client-go/pkg/api"
@@ -15,9 +13,8 @@ var validServiceTypes = map[api.ServiceType]bool{
 }
 
 type Config struct {
-	ConfigFile         string        `split_words:"true"`
-	DefaultServiceType string        `split_words:"true" default:"LoadBalancer"`
-	Timeout            time.Duration `default:"30s"`
+	ConfigFile         string `split_words:"true"`
+	DefaultServiceType string `split_words:"true" default:"LoadBalancer"`
 }
 
 type Client interface {


### PR DESCRIPTION
That timeout broke api streams (app log and deploy)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luizalabs/teresa-api/224)
<!-- Reviewable:end -->
