### PR TITLE
No TLS by default

### DIFF
--- a/cmd/client/cmd/app.go
+++ b/cmd/client/cmd/app.go
@@ -102,7 +102,7 @@ func createApp(cmd *cobra.Command, args []string) {
 		client.PrintErrorAndExit("Invalid process-type parameter")
 	}
 
-	conn, err := connection.New(cfgFile, &connOpts)
+	conn, err := connection.New(cfgFile)
 	if err != nil {
 		client.PrintErrorAndExit("Error connecting to server: %v", err)
 	}
@@ -201,7 +201,7 @@ func appInfo(cmd *cobra.Command, args []string) {
 	}
 	name := args[0]
 
-	conn, err := connection.New(cfgFile, &connOpts)
+	conn, err := connection.New(cfgFile)
 	if err != nil {
 		client.PrintErrorAndExit("Error connecting to server: %v", err)
 	}
@@ -316,7 +316,7 @@ func appEnvSet(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	conn, err := connection.New(cfgFile, &connOpts)
+	conn, err := connection.New(cfgFile)
 	if err != nil {
 		client.PrintErrorAndExit("Error connecting to server: %s", err)
 	}
@@ -382,7 +382,7 @@ func appEnvUnset(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	conn, err := connection.New(cfgFile, &connOpts)
+	conn, err := connection.New(cfgFile)
 	if err != nil {
 		client.PrintErrorAndExit("Error connecting to server: %s", err)
 	}
@@ -456,7 +456,7 @@ func appLogs(cmd *cobra.Command, args []string) {
 	lines, _ := cmd.Flags().GetInt64("lines")
 	follow, _ := cmd.Flags().GetBool("follow")
 
-	conn, err := connection.New(cfgFile, &connOpts)
+	conn, err := connection.New(cfgFile)
 	if err != nil {
 		client.PrintErrorAndExit("Error connecting to server: %v", err)
 	}

--- a/cmd/client/cmd/config.go
+++ b/cmd/client/cmd/config.go
@@ -110,9 +110,18 @@ func setCluster(cmd *cobra.Command, args []string) {
 	if server == "" {
 		client.PrintErrorAndExit("Server URI not provided")
 	}
-	useTLS, _ := cmd.Flags().GetBool("tls")
-	insecure, _ := cmd.Flags().GetBool("tlsinsecure")
-	current, _ := cmd.Flags().GetBool("current")
+	useTLS, err := cmd.Flags().GetBool("tls")
+	if err != nil {
+		client.PrintErrorAndExit("Invalid tls parameter")
+	}
+	insecure, err := cmd.Flags().GetBool("tlsinsecure")
+	if err != nil {
+		client.PrintErrorAndExit("Invalid tlsinsecure parameter")
+	}
+	current, err := cmd.Flags().GetBool("current")
+	if err != nil {
+		client.PrintErrorAndExit("Invalid current parameter")
+	}
 	name := args[0]
 
 	c, err := client.ReadConfigFile(cfgFile)

--- a/cmd/client/cmd/deploy.go
+++ b/cmd/client/cmd/deploy.go
@@ -177,7 +177,7 @@ func deployApp(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	conn, err := connection.New(cfgFile, &connOpts)
+	conn, err := connection.New(cfgFile)
 	if err != nil {
 		client.PrintErrorAndExit("Error connecting to server: %v", err)
 	}

--- a/cmd/client/cmd/login_cluster.go
+++ b/cmd/client/cmd/login_cluster.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"fmt"
-
 	context "golang.org/x/net/context"
 
+	"github.com/fatih/color"
 	"github.com/luizalabs/teresa-api/cmd/client/connection"
 	"github.com/luizalabs/teresa-api/pkg/client"
 	"github.com/spf13/cobra"
@@ -48,7 +47,7 @@ func login(cmd *cobra.Command, args []string) {
 	if err != nil {
 		client.PrintErrorAndExit(client.GetErrorMsg(err))
 	}
-	fmt.Println("Login OK")
+	color.Green("Login OK")
 
 	if err = client.SaveToken(cfgFile, res.Token); err != nil {
 		client.PrintErrorAndExit("Error trying to save token in configuration file: %v", err)

--- a/cmd/client/cmd/login_cluster.go
+++ b/cmd/client/cmd/login_cluster.go
@@ -37,7 +37,7 @@ func login(cmd *cobra.Command, args []string) {
 		client.PrintErrorAndExit("Error trying to get the user password: %v", err)
 	}
 
-	conn, err := connection.New(cfgFile, &connOpts)
+	conn, err := connection.New(cfgFile)
 	if err != nil {
 		client.PrintErrorAndExit("Error connecting to server: %v", err)
 	}

--- a/cmd/client/cmd/root.go
+++ b/cmd/client/cmd/root.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/luizalabs/teresa-api/cmd/client/connection"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/x-cray/logrus-prefixed-formatter"
@@ -16,8 +15,6 @@ import (
 
 // log object to use over the cli
 var log *logrus.Logger
-
-var connOpts connection.Options
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
@@ -98,15 +95,11 @@ func init() {
 	RootCmd.SuggestionsMinimumDistance = 3
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file")
 	RootCmd.PersistentFlags().BoolVar(&debugFlag, "debug", false, "debug mode")
-	RootCmd.PersistentFlags().BoolVar(&connOpts.TLSInsecure, "tlsinsecure", false, "allow insecure TLS connections")
-	RootCmd.PersistentFlags().BoolVar(&connOpts.NoTLS, "notls", false, "disable TLS")
 	RootCmd.PersistentFlags().MarkHidden("debug")
 }
 
 func initLog() {
-	// TODO: melhorar o log e enviar logs para o logentries
 	log = logrus.New()
-	// lgr.Formatter = new(logrus.JSONFormatter)
 	log.Formatter = new(prefixed.TextFormatter)
 	log.Out = os.Stdout
 	log.Level = logrus.InfoLevel

--- a/cmd/client/cmd/team.go
+++ b/cmd/client/cmd/team.go
@@ -71,7 +71,7 @@ func createTeam(cmd *cobra.Command, args []string) {
 	email, _ := cmd.Flags().GetString("email")
 	url, _ := cmd.Flags().GetString("url")
 
-	conn, err := connection.New(cfgFile, &connOpts)
+	conn, err := connection.New(cfgFile)
 	if err != nil {
 		client.PrintErrorAndExit("Error connecting to server: %v", err)
 	}
@@ -99,7 +99,7 @@ func teamAddUser(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	conn, err := connection.New(cfgFile, &connOpts)
+	conn, err := connection.New(cfgFile)
 	if err != nil {
 		client.PrintErrorAndExit("Error connecting to server: %v", err)
 	}
@@ -116,7 +116,7 @@ func teamAddUser(cmd *cobra.Command, args []string) {
 func teamList(cmd *cobra.Command, args []string) {
 	showUsers, _ := cmd.Flags().GetBool("show-users")
 
-	conn, err := connection.New(cfgFile, &connOpts)
+	conn, err := connection.New(cfgFile)
 	if err != nil {
 		client.PrintErrorAndExit("Error connecting to server: %v", err)
 	}

--- a/cmd/client/cmd/user.go
+++ b/cmd/client/cmd/user.go
@@ -48,7 +48,7 @@ func setPassword(cmd *cobra.Command, args []string) {
 		client.PrintErrorAndExit("Error trying to get the user password: %v", err)
 	}
 
-	conn, err := connection.New(cfgFile, &connOpts)
+	conn, err := connection.New(cfgFile)
 	if err != nil {
 		client.PrintErrorAndExit("Error connecting to server: %v", err)
 	}
@@ -67,7 +67,7 @@ func deleteUser(cmd *cobra.Command, args []string) {
 		cmd.Usage()
 		return
 	}
-	conn, err := connection.New(cfgFile, &connOpts)
+	conn, err := connection.New(cfgFile)
 	if err != nil {
 		client.PrintErrorAndExit("Error connecting to server: %v", err)
 	}
@@ -105,7 +105,7 @@ func createUser(cmd *cobra.Command, args []string) {
 		cmd.Usage()
 		return
 	}
-	conn, err := connection.New(cfgFile, &connOpts)
+	conn, err := connection.New(cfgFile)
 	if err != nil {
 		client.PrintErrorAndExit("Error connecting to server: %v", err)
 	}

--- a/cmd/client/connection/connection.go
+++ b/cmd/client/connection/connection.go
@@ -5,15 +5,10 @@ import (
 	"google.golang.org/grpc"
 )
 
-type Options struct {
-	NoTLS       bool
-	TLSInsecure bool
-}
-
-func New(cfgFile string, opts *Options) (*grpc.ClientConn, error) {
+func New(cfgFile string) (*grpc.ClientConn, error) {
 	cfg, err := client.GetConfig(cfgFile)
 	if err != nil {
 		return nil, err
 	}
-	return client.New(*cfg, opts.NoTLS, opts.TLSInsecure)
+	return client.New(*cfg)
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -19,20 +19,20 @@ func (t *tokenAuth) GetRequestMetadata(context.Context, ...string) (map[string]s
 
 func (*tokenAuth) RequireTransportSecurity() bool { return false }
 
-func New(cfg ClusterConfig, noTLS, tlsInsecure bool) (*grpc.ClientConn, error) {
+func New(cfg ClusterConfig) (*grpc.ClientConn, error) {
 	tlsConfig := new(tls.Config)
 
 	opts := []grpc.DialOption{
 		grpc.WithPerRPCCredentials(&tokenAuth{cfg.Token}),
 	}
-	if noTLS {
-		opts = append(opts, grpc.WithInsecure())
-	} else {
-		if tlsInsecure {
+	if cfg.UseTLS {
+		if cfg.Insecure {
 			tlsConfig.InsecureSkipVerify = true
 		}
 		creds := credentials.NewTLS(tlsConfig)
 		opts = append(opts, grpc.WithTransportCredentials(creds))
+	} else {
+		opts = append(opts, grpc.WithInsecure())
 	}
 
 	return grpc.Dial(cfg.Server, opts...)

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -12,8 +12,10 @@ import (
 )
 
 type ClusterConfig struct {
-	Server string `yaml:"server"`
-	Token  string `yaml:"token"`
+	Server   string `yaml:"server"`
+	Token    string `yaml:"token"`
+	UseTLS   bool   `yaml:"tls"`
+	Insecure bool   `yaml:"insecure"`
 }
 
 type Config struct {

--- a/pkg/client/testdata/validConfigFile.yaml
+++ b/pkg/client/testdata/validConfigFile.yaml
@@ -2,7 +2,11 @@ clusters:
   cluster-a:
     server: https://teresa-a.com
     token: auth-token-cluster-a
+    tls: false
+    insecure: false
   cluster-b:
     server: https://teresa-b.com
     token: auth-token-cluster-b
+    tls: true
+    insecure: false
 current_cluster: cluster-a

--- a/pkg/server/cmd/run.go
+++ b/pkg/server/cmd/run.go
@@ -23,7 +23,7 @@ var runCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(runCmd)
 	runCmd.Flags().String("port", "50051", "TCP port to create a listener")
-	runCmd.Flags().Bool("notls", false, "disable TLS")
+	runCmd.Flags().Bool("tls", false, "enable TLS")
 }
 
 func runServer(cmd *cobra.Command, args []string) {
@@ -32,9 +32,9 @@ func runServer(cmd *cobra.Command, args []string) {
 		log.WithError(err).Fatal("invalid port parameter")
 	}
 
-	notls, err := cmd.Flags().GetBool("notls")
+	useTLS, err := cmd.Flags().GetBool("tls")
 	if err != nil {
-		log.WithError(err).Fatal("invalid notls parameter")
+		log.WithError(err).Fatal("invalid tls parameter")
 	}
 
 	db, err := getDB()
@@ -63,7 +63,7 @@ func runServer(cmd *cobra.Command, args []string) {
 	}
 
 	var tlsCert *tls.Certificate
-	if !notls {
+	if useTLS {
 		tlsCert, err = sec.TLSCertificate()
 		if err != nil {
 			log.WithError(err).Fatal("failed to get TLS cert")


### PR DESCRIPTION
To simplify the up and run process for new users, this PR changes the default behavior of server and client to **don't** use TLS by default.

Today we need to use the flag `--notls` for each command. With this PR you only need to use the flag `--tls` when you use the `set-cluster`  command if you want to use TLS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luizalabs/teresa-api/227)
<!-- Reviewable:end -->
