### PR TITLE
[Proposal] Make slug images configurable by env vars

### DIFF
--- a/pkg/server/deploy/build.go
+++ b/pkg/server/deploy/build.go
@@ -9,9 +9,7 @@ import (
 )
 
 const (
-	slugBuilderImage = "luizalabs/slugbuilder:v2.4.9"
-	slugRunnerImage  = "luizalabs/slugrunner:v2.2.4"
-	DefaultPort      = 5000
+	DefaultPort = 5000
 )
 
 type PodVolumeMountsSpec struct {
@@ -65,10 +63,10 @@ func newPodSpec(name, image string, a *app.App, envVars map[string]string, fileS
 	return ps
 }
 
-func newBuildSpec(a *app.App, deployId, tarBallLocation, buildDest string, fileStorage st.Storage) *PodSpec {
+func newBuildSpec(a *app.App, deployId, tarBallLocation, buildDest string, fileStorage st.Storage, opts *Options) *PodSpec {
 	return newPodSpec(
 		fmt.Sprintf("build-%s", deployId),
-		slugBuilderImage,
+		opts.SlugBuilderImage,
 		a,
 		map[string]string{
 			"TAR_PATH":        tarBallLocation,
@@ -79,10 +77,10 @@ func newBuildSpec(a *app.App, deployId, tarBallLocation, buildDest string, fileS
 	)
 }
 
-func newDeploySpec(a *app.App, tYaml *TeresaYaml, fileStorage st.Storage, description, slugURL, processType string, rhl int) *DeploySpec {
+func newDeploySpec(a *app.App, tYaml *TeresaYaml, fileStorage st.Storage, description, slugURL, processType string, opts *Options) *DeploySpec {
 	ps := newPodSpec(
 		a.Name,
-		slugRunnerImage,
+		opts.SlugRunnerImage,
 		a,
 		map[string]string{
 			"APP":             a.Name,
@@ -98,7 +96,7 @@ func newDeploySpec(a *app.App, tYaml *TeresaYaml, fileStorage st.Storage, descri
 		Description:          description,
 		SlugURL:              slugURL,
 		PodSpec:              *ps,
-		RevisionHistoryLimit: rhl,
+		RevisionHistoryLimit: opts.RevisionHistoryLimit,
 	}
 
 	if tYaml != nil {
@@ -112,10 +110,10 @@ func newDeploySpec(a *app.App, tYaml *TeresaYaml, fileStorage st.Storage, descri
 	return ds
 }
 
-func newRunCommandSpec(a *app.App, deployId, command, slugURL string, fileStorage st.Storage) *PodSpec {
+func newRunCommandSpec(a *app.App, deployId, command, slugURL string, fileStorage st.Storage, opts *Options) *PodSpec {
 	ps := newPodSpec(
 		fmt.Sprintf("release-%s-%s", a.Name, deployId),
-		slugRunnerImage,
+		opts.SlugRunnerImage,
 		a,
 		map[string]string{
 			"APP":             a.Name,

--- a/pkg/server/deploy/build_test.go
+++ b/pkg/server/deploy/build_test.go
@@ -49,6 +49,7 @@ func TestNewBuildSpec(t *testing.T) {
 	expectedDeployId := "123"
 	expectedTarBallLocation := "narnia"
 	expectedBuildDest := "nowhere"
+	opts := &Options{SlugBuilderImage: "image"}
 
 	ps := newBuildSpec(
 		&app.App{},
@@ -56,14 +57,15 @@ func TestNewBuildSpec(t *testing.T) {
 		expectedTarBallLocation,
 		expectedBuildDest,
 		st.NewFake(),
+		opts,
 	)
 
 	if !strings.HasSuffix(ps.Name, expectedDeployId) {
 		t.Errorf("expected build-%s, got %s", expectedDeployId, ps.Name)
 	}
 
-	if ps.Image != slugBuilderImage {
-		t.Errorf("expected %s, got %s", slugBuilderImage, ps.Image)
+	if ps.Image != opts.SlugBuilderImage {
+		t.Errorf("expected %s, got %s", opts.SlugBuilderImage, ps.Image)
 	}
 
 	ev := map[string]string{
@@ -83,14 +85,15 @@ func TestNewCommandRunSpec(t *testing.T) {
 	expectedBuildId := "1234"
 	a := &app.App{Name: "teresa"}
 	s := st.NewFake()
+	opts := &Options{SlugRunnerImage: "image"}
 
-	ps := newRunCommandSpec(a, expectedBuildId, expectedCommand, expectedSlugURL, s)
+	ps := newRunCommandSpec(a, expectedBuildId, expectedCommand, expectedSlugURL, s, opts)
 	if !strings.HasSuffix(ps.Name, fmt.Sprintf("%s-%s", a.Name, expectedBuildId)) {
 		t.Errorf("expected release-%s-%s, got %s", a.Name, expectedBuildId, ps.Name)
 	}
 
-	if ps.Image != slugRunnerImage {
-		t.Errorf("expected %s, got %s", slugRunnerImage, ps.Image)
+	if ps.Image != opts.SlugRunnerImage {
+		t.Errorf("expected %s, got %s", opts.SlugRunnerImage, ps.Image)
 	}
 
 	ev := map[string]string{
@@ -109,7 +112,7 @@ func TestNewDeploySpec(t *testing.T) {
 	expectedSlugURL := "http://teresa.io/slug.tgz"
 	expectedProcessType := "worker"
 	expectedName := "deploy-test"
-	expectedRevisionHistoryLimit := 5
+	opts := &Options{RevisionHistoryLimit: 5}
 
 	ds := newDeploySpec(
 		&app.App{Name: expectedName},
@@ -118,7 +121,7 @@ func TestNewDeploySpec(t *testing.T) {
 		expectedDescription,
 		expectedSlugURL,
 		expectedProcessType,
-		expectedRevisionHistoryLimit,
+		opts,
 	)
 
 	if len(ds.Args) != 2 || ds.Args[1] != expectedProcessType {
@@ -137,7 +140,7 @@ func TestNewDeploySpec(t *testing.T) {
 		t.Errorf("expected %s, got %s", expectedName, ds.PodSpec.Name)
 	}
 
-	if ds.RevisionHistoryLimit != expectedRevisionHistoryLimit {
-		t.Errorf("expected %d, got %d", expectedRevisionHistoryLimit, ds.RevisionHistoryLimit)
+	if ds.RevisionHistoryLimit != opts.RevisionHistoryLimit {
+		t.Errorf("expected %d, got %d", opts.RevisionHistoryLimit, ds.RevisionHistoryLimit)
 	}
 }

--- a/pkg/server/deploy/deploy_test.go
+++ b/pkg/server/deploy/deploy_test.go
@@ -61,7 +61,7 @@ func TestDeployPermissionDenied(t *testing.T) {
 		st.NewFake(),
 	)
 	u := &storage.User{Email: "bad-user@luizalabs.com"}
-	if _, err := ops.Deploy(u, "teresa", &fakeReadSeeker{}, "test", 1); err != auth.ErrPermissionDenied {
+	if _, err := ops.Deploy(u, "teresa", &fakeReadSeeker{}, "test", &Options{}); err != auth.ErrPermissionDenied {
 		t.Errorf("expecter ErrPermissionDenied, got %v", err)
 	}
 }
@@ -88,7 +88,7 @@ func TestDeploy(t *testing.T) {
 		st.NewFake(),
 	)
 	u := &storage.User{Email: "gopher@luizalabs.com"}
-	r, err := ops.Deploy(u, "teresa", tarBall, "test", 1)
+	r, err := ops.Deploy(u, "teresa", tarBall, "test", &Options{})
 	if err != nil {
 		t.Fatal("error making deploy:", err)
 	}
@@ -100,7 +100,7 @@ func TestCreateDeploy(t *testing.T) {
 	a := &app.App{Name: expectedName}
 	expectedDescription := "test-description"
 	expectedSlugURL := "test-slug"
-	expectedRevisionHistoryLimit := 3
+	opts := &Options{RevisionHistoryLimit: 3}
 
 	fakeK8s := new(fakeK8sOperations)
 	ops := NewDeployOperations(
@@ -115,7 +115,7 @@ func TestCreateDeploy(t *testing.T) {
 		nil,
 		expectedDescription,
 		expectedSlugURL,
-		expectedRevisionHistoryLimit,
+		opts,
 	)
 
 	if err != nil {
@@ -131,8 +131,8 @@ func TestCreateDeploy(t *testing.T) {
 	if fakeK8s.lastDeploySpec.SlugURL != expectedSlugURL {
 		t.Errorf("expected %s, got %s", expectedSlugURL, fakeK8s.lastDeploySpec.SlugURL)
 	}
-	if fakeK8s.lastDeploySpec.RevisionHistoryLimit != expectedRevisionHistoryLimit {
-		t.Errorf("expected %d, got %d", expectedRevisionHistoryLimit, fakeK8s.lastDeploySpec.RevisionHistoryLimit)
+	if fakeK8s.lastDeploySpec.RevisionHistoryLimit != opts.RevisionHistoryLimit {
+		t.Errorf("expected %d, got %d", opts.RevisionHistoryLimit, fakeK8s.lastDeploySpec.RevisionHistoryLimit)
 	}
 }
 
@@ -152,7 +152,7 @@ func TestCreateDeployReturnError(t *testing.T) {
 		nil,
 		"some desc",
 		"some slug",
-		1,
+		&Options{},
 	)
 
 	if err != expectedErr {
@@ -230,6 +230,7 @@ func TestBuildApp(t *testing.T) {
 			"123456",
 			"/slug.tgz",
 			new(bytes.Buffer),
+			&Options{},
 		)
 
 		if err != tc.expectedErr {
@@ -268,6 +269,7 @@ func TestRunReleaseCmd(t *testing.T) {
 			"123456",
 			"/slug.tgz",
 			new(bytes.Buffer),
+			&Options{},
 		)
 
 		if err != tc.expectedErr {

--- a/pkg/server/deploy/handlers.go
+++ b/pkg/server/deploy/handlers.go
@@ -20,6 +20,8 @@ const (
 type Options struct {
 	KeepAliveTimeout     time.Duration `split_words:"true" default:"30s"`
 	RevisionHistoryLimit int           `split_words:"true" default:"5"`
+	SlugBuilderImage     string        `split_words:"true" default:"luizalabs/slugbuilder:v2.4.9"`
+	SlugRunnerImage      string        `split_words:"true" default:"luizalabs/slugrunner:v2.2.4"`
 }
 
 type Service struct {
@@ -52,7 +54,7 @@ func (s *Service) Make(stream dpb.Deploy_MakeServer) error {
 	}
 
 	rs := bytes.NewReader(content.Bytes())
-	rc, err := s.ops.Deploy(u, appName, rs, description, s.options.RevisionHistoryLimit)
+	rc, err := s.ops.Deploy(u, appName, rs, description, s.options)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We should be able to change the images fast (for security patches for instance) and without a new deploy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luizalabs/teresa-api/231)
<!-- Reviewable:end -->
