### PR TITLE
add `PYTHONPATH` as a protected env variable

### DIFF
--- a/pkg/server/slug/slug.go
+++ b/pkg/server/slug/slug.go
@@ -2,6 +2,7 @@ package slug
 
 var (
 	ProtectedEnvVars = [...]string{
+		"PYTHONPATH",
 		"SLUG_URL",
 		"PORT",
 		"DEIS_DEBUG",


### PR DESCRIPTION
Because with a wrong python-path the slugbuilder doesn't works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luizalabs/teresa-api/240)
<!-- Reviewable:end -->
