### PR TITLE
Better Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ COPY . /go/src/github.com/luizalabs/teresa-api
 
 RUN make build-server
 
-CMD ["./teresa-server", "run", "--port", "8080"]
-EXPOSE 8080
+ENTRYPOINT ["./teresa-server"]
+CMD ["run"]
+EXPOSE 50051


### PR DESCRIPTION
- use default grpc port
- use ENTRYPOINT, which is more flexible: we can vary the command
  parameters without rebuilding the image

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luizalabs/teresa-api/249)
<!-- Reviewable:end -->
