### PR TITLE
update default versions of slugbuilder and slugrunner

### DIFF
--- a/pkg/server/deploy/handlers.go
+++ b/pkg/server/deploy/handlers.go
@@ -19,8 +19,8 @@ const (
 type Options struct {
 	KeepAliveTimeout     time.Duration `split_words:"true" default:"30s"`
 	RevisionHistoryLimit int           `split_words:"true" default:"5"`
-	SlugBuilderImage     string        `split_words:"true" default:"luizalabs/slugbuilder:v2.4.9"`
-	SlugRunnerImage      string        `split_words:"true" default:"luizalabs/slugrunner:v2.2.4"`
+	SlugBuilderImage     string        `split_words:"true" default:"luizalabs/slugbuilder:v2.5.0"`
+	SlugRunnerImage      string        `split_words:"true" default:"luizalabs/slugrunner:v2.4.0"`
 }
 
 type Service struct {


### PR DESCRIPTION
Those versions fix the support for minio as slug storage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luizalabs/teresa-api/256)
<!-- Reviewable:end -->
