### PR TITLE
only check password length in `set-password` command

### DIFF
--- a/pkg/client/cmd/user.go
+++ b/pkg/client/cmd/user.go
@@ -47,6 +47,9 @@ func setPassword(cmd *cobra.Command, args []string) {
 	if err != nil {
 		client.PrintErrorAndExit("Error trying to get the user password: %v", err)
 	}
+	if err = client.EnsurePasswordLength(p); err != nil {
+		client.PrintErrorAndExit(err.Error())
+	}
 
 	conn, err := connection.New(cfgFile)
 	if err != nil {

--- a/pkg/client/password.go
+++ b/pkg/client/password.go
@@ -10,7 +10,7 @@ const (
 	minPassLen = 8
 )
 
-func checkPassword(pass string) error {
+func EnsurePasswordLength(pass string) error {
 	if len([]rune(pass)) < minPassLen {
 		return fmt.Errorf("minimum password length is %d", minPassLen)
 	}
@@ -24,8 +24,5 @@ func GetMaskedPassword(prompt string) (string, error) {
 		return "", err
 	}
 	fmt.Print("\r")
-	if err := checkPassword(string(p)); err != nil {
-		return "", err
-	}
 	return string(p), nil
 }

--- a/pkg/client/password_test.go
+++ b/pkg/client/password_test.go
@@ -14,7 +14,7 @@ func TestCheckPassword(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		if err := checkPassword(tc.pass); (err != nil && !tc.expectError) || (err == nil && tc.expectError) {
+		if err := EnsurePasswordLength(tc.pass); (err != nil && !tc.expectError) || (err == nil && tc.expectError) {
 			t.Errorf("expect error %v, got error %v", tc.expectError, err)
 		}
 	}


### PR DESCRIPTION
To prevent access troubles for users already saved with a weak password length.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/luizalabs/teresa-api/261)
<!-- Reviewable:end -->
